### PR TITLE
feat: allows for no points to be passed to SAM predictor

### DIFF
--- a/ros2_sam/ros2_sam/sam.py
+++ b/ros2_sam/ros2_sam/sam.py
@@ -40,6 +40,9 @@ class SAM:
 
     def segment(self, img, points, point_labels, boxes=None, multimask=True):
         self._predictor.set_image(img)
+        if len(points) == 0:
+            points = None
+            point_labels = None
         return self._predictor.predict(
             point_coords=points,
             point_labels=point_labels,


### PR DESCRIPTION
SAM predictor API requires that if there are no points passed to the predict call (only bounding boxes) then the points and point_labels are both set to None. This PR enables this edge case to be handled by the ros2 API.